### PR TITLE
Add Python fault example

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,12 @@ Python port:
 uv run python example/python_example.py
 ```
 
+For a version that inserts simple faults into the synthetic image run:
+
+```
+uv run python example/python_fault_example.py
+```
+
 Before running, install the required Python packages in the `uv` environment:
 
 ```

--- a/example/python_fault_example.py
+++ b/example/python_fault_example.py
@@ -1,0 +1,15 @@
+from pyrgm import RGM2, add_faults
+import numpy as np
+
+if __name__ == "__main__":
+    model = RGM2(n1=400, n2=420, nl=40, seed=324343)
+    image = model.generate()
+    image = add_faults(
+        image,
+        nf=17,
+        dip_range=(60.0, 120.0),
+        disp_range=(-10.0, 10.0),
+        seed=324343,
+    )
+    image.astype("<f4").tofile("python_fault_example.bin")
+    print("generated python_fault_example.bin")

--- a/pyrgm/__init__.py
+++ b/pyrgm/__init__.py
@@ -1,5 +1,6 @@
 from .rgm2 import RGM2
 from . import utility
 from .utility import *
+from .fault import add_faults
 
-__all__ = ["RGM2"] + utility.__all__
+__all__ = ["RGM2", "add_faults"] + utility.__all__

--- a/pyrgm/fault.py
+++ b/pyrgm/fault.py
@@ -1,0 +1,37 @@
+import numpy as np
+
+
+def add_faults(
+    image: np.ndarray,
+    nf: int = 1,
+    dip_range: tuple[float, float] = (60.0, 120.0),
+    disp_range: tuple[float, float] = (-10.0, 10.0),
+    seed: int | None = None,
+) -> np.ndarray:
+    """Insert simple linear faults into an image.
+
+    This is a lightweight approximation of the Fortran fault generator.
+    Faults are represented by straight lines with a constant displacement
+    applied to one side of the line.
+    """
+    rng = np.random.default_rng(seed)
+    result = np.copy(image)
+    n1, n2 = result.shape
+    for _ in range(nf):
+        angle = np.radians(rng.uniform(*dip_range))
+        disp = rng.uniform(*disp_range)
+        x0 = rng.uniform(0, n2)
+        z0 = rng.uniform(0, n1)
+        k = int(round(disp))
+        line = np.tan(angle) * (np.arange(n2) - x0) + z0
+        for j, i in enumerate(line.astype(int)):
+            if 0 <= i < n1:
+                if k > 0:
+                    seg = result[i:, j]
+                    result[i:, j] = np.roll(seg, k)
+                    result[i:i + k, j] = seg[0]
+                elif k < 0:
+                    seg = result[: i + 1, j]
+                    result[: i + 1, j] = np.roll(seg, k)
+                    result[i + k + 1 : i + 1, j] = seg[-1]
+    return result


### PR DESCRIPTION
## Summary
- port fault example to Python with a helper function
- expose `add_faults` in the package init
- document running the new fault example

## Testing
- `python -m py_compile pyrgm/rgm2.py pyrgm/utility.py pyrgm/fault.py example/python_fault_example.py python_example.py`
- `PYTHONPATH=. python example/python_fault_example.py` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_68412f6d0e18832dadc1089c1852a957